### PR TITLE
guild admin page fixes

### DIFF
--- a/qs-client/src/components/guild-card.vue
+++ b/qs-client/src/components/guild-card.vue
@@ -89,7 +89,7 @@ const GuildCardProps = Vue.extend({
 })
 export default class GuildCard extends GuildCardProps {
   group: "public";
-  guild: Guild;
+  guild: Partial<Guild> = {};
   guild_id: null;
   isAdmin: false;
   invitation: boolean;

--- a/qs-client/src/components/guilds-table.vue
+++ b/qs-client/src/components/guilds-table.vue
@@ -165,7 +165,7 @@ const GuildsTableProp = Vue.extend({
           required: false,
           label: "Ongoing Quests",
           align: "left",
-          field: "ongoing_quest_count",
+          field: "ongoing_quests_count",
           sortable: true,
         },
         {
@@ -173,7 +173,7 @@ const GuildsTableProp = Vue.extend({
           required: false,
           label: "Quests Completed",
           align: "left",
-          field: "finished_quest_count",
+          field: "finished_quests_count",
           sortable: true,
         },
         {

--- a/qs-client/src/store/guilds.ts
+++ b/qs-client/src/store/guilds.ts
@@ -299,8 +299,8 @@ export const guilds = (axios: AxiosInstance) =>
           is_admin: true,
           last_node_published_at: null,
           node_count: 0,
-          ongoing_quest_count: 0,
-          finished_quest_count: 0,
+          ongoing_quests_count: 0,
+          finished_quests_count: 0,
           recruiting_for_quest_count: 0,
         });
         state.guilds = { ...state.guilds, [guildData.id]: guildData };
@@ -326,8 +326,8 @@ export const guilds = (axios: AxiosInstance) =>
           is_admin: undefined,
           last_node_published_at: undefined,
           node_count: undefined,
-          ongoing_quest_count: undefined,
-          finished_quest_count: undefined,
+          ongoing_quests_count: undefined,
+          finished_quests_count: undefined,
           recruiting_for_quest_count: undefined,
         });
       },

--- a/qs-client/src/types.ts
+++ b/qs-client/src/types.ts
@@ -163,8 +163,8 @@ export interface GuildData extends Guild {
   is_admin: boolean;
   last_node_published_at: string;
   node_count: number;
-  ongoing_quest_count: number;
-  finished_quest_count: number;
+  ongoing_quests_count: number;
+  finished_quests_count: number;
   recruiting_for_quest_count: number;
 }
 

--- a/qs-server/deploy/data_views.sql
+++ b/qs-server/deploy/data_views.sql
@@ -78,6 +78,7 @@ CREATE OR REPLACE VIEW public.guilds_data AS
     guilds.description AS description,
     guilds.creator AS creator,
     guilds.open_for_applications AS open_for_applications,
+    guilds.public AS public,
     guilds.application_needs_approval AS application_needs_approval,
     guilds.created_at AS created_at,
     guilds.updated_at AS updated_at,

--- a/qs-server/test/casting.test.ts
+++ b/qs-server/test/casting.test.ts
@@ -39,7 +39,7 @@ describe('\'casting\' service', function() {
       it('creates public quest', async function() {
         const publicQuestModel = await axiosUtil.create('quests', publicQuestInfo, sponsorToken);
         publicQuestId = publicQuestModel.id;
-        const quests = await axiosUtil.get('quests', {}, leaderToken);
+        const quests = await axiosUtil.get('quests', {}, sponsorToken);
         assert.equal(quests.length, 1);
       });
       it('creates public guild', async function() {

--- a/qs-server/test/game_play.test.ts
+++ b/qs-server/test/game_play.test.ts
@@ -36,7 +36,7 @@ describe('\'game_play\' service', function() {
       it('creates public quest', async function() {
         const publicQuestModel = await axiosUtil.create('quests', draftPublicQuestInfo, sponsorToken);
         publicQuestId = publicQuestModel.id;
-        const quests = await axiosUtil.get('quests', {}, leaderToken);
+        const quests = await axiosUtil.get('quests', {}, sponsorToken);
         assert.equal(quests.length, 1);
       });
       it('creates public guild', async function() {

--- a/qs-server/test/role.test.ts
+++ b/qs-server/test/role.test.ts
@@ -43,7 +43,7 @@ describe('\'role\' service', function() {
       it('creates public quest', async function() {
         const publicQuestModel = await axiosUtil.create('quests', publicQuestInfo, sponsorToken);
         publicQuestId = publicQuestModel.id;
-        const quests = await axiosUtil.get('quests', {}, leaderToken);
+        const quests = await axiosUtil.get('quests', {}, sponsorToken);
         assert.equal(quests.length, 1);
       });
       it('creates public guild', async function() {


### PR DESCRIPTION
Fixed guild admin radio buttons for invitation. And to public/private radio buttons. Also changed ongoing_quests_count and finished_quests_count to match FE and BE. Also add guilds.public to guilds_data. 